### PR TITLE
Remove chained assignement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const axios = require("axios")
 const cheerio = require("cheerio")
 const util = require("./util")
 
-module.exports = getFbVideoInfo = async (videoUrl, cookie, useragent)=>{
+module.exports = async function getFbVideoInfo(videoUrl, cookie, useragent) {
     return new Promise((resolve, reject)=>{
         const headers = {
             "sec-fetch-user": "?1",


### PR DESCRIPTION
Chained assignments are not supported in strict mode and throw a `ReferenceError`.

Most bundler will make it a ES modules, which are always in strict mode. It is generally recommended to always assume strict mode.